### PR TITLE
Added flags that allow ipv6 databases to be used

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -79,9 +79,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     geoip_initialize = ::GeoIP.new(@database)
 
     @geoip_type = case geoip_initialize.database_type
-    when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1
+    when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1, GeoIP::GEOIP_CITY_EDITION_REV1_V6
       :city
-    when GeoIP::GEOIP_COUNTRY_EDITION
+    when GeoIP::GEOIP_COUNTRY_EDITION, GeoIP::GEOIP_COUNTRY_EDITION_V6
       :country
     when GeoIP::GEOIP_ASNUM_EDITION
       :asn


### PR DESCRIPTION
I've added the flags that make the plugin support ipv6 city and country databases.

I was unable to get the rspec test suite running (even in pristine mode), probably due to the separate repository setup, but I've verified that this works using a simple test config and the getting started setup. Test databases were retrieved from maxmind using the `geoip-database-contrib` package in ubuntu trusty (multiverse).