### PR TITLE
fix ipv6 support for geoip

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 @files=[ {'url' => 'http://logstash.objects.dreamhost.com/maxmind/GeoLiteCity-2013-01-18.dat.gz', 'sha1' => '15aab9a90ff90c4784b2c48331014d242b86bf82' },
-         {'url' => 'http://logstash.objects.dreamhost.com/maxmind/GeoIPASNum-2014-02-12.dat.gz', 'sha1' => '6f33ca0b31e5f233e36d1f66fbeae36909b58f91' }
+         {'url' => 'http://logstash.objects.dreamhost.com/maxmind/GeoIPASNum-2014-02-12.dat.gz', 'sha1' => '6f33ca0b31e5f233e36d1f66fbeae36909b58f91' },
+         {'url' => 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz', 'sha1' => '66f2e420126a94d9e719280b85e8639c6be3001b' }
   ]
 
 task :default do

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -64,7 +64,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   def register
     require "geoip"
     if @database.nil?
-      @database = ::Dir.glob(::File.join(::File.expand_path("../../../vendor/", ::File.dirname(__FILE__)),"GeoLiteCity*.dat")).first
+      @database = ::Dir.glob(::File.join(::File.expand_path("../../../vendor/", ::File.dirname(__FILE__)),"GeoLiteCity-*.dat")).first
       if !File.exists?(@database)
         raise "You must specify 'database => ...' in your geoip filter (I looked for '#{@database}'"
       end
@@ -77,9 +77,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     geoip_initialize = ::GeoIP.new(@database)
 
     @geoip_type = case geoip_initialize.database_type
-    when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1
+    when GeoIP::GEOIP_CITY_EDITION_REV0, GeoIP::GEOIP_CITY_EDITION_REV1, GeoIP::GEOIP_CITY_EDITION_REV1_V6
       :city
-    when GeoIP::GEOIP_COUNTRY_EDITION
+    when GeoIP::GEOIP_COUNTRY_EDITION, GeoIP::GEOIP_COUNTRY_EDITION_V6
       :country
     when GeoIP::GEOIP_ASNUM_EDITION
       :asn

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -118,4 +118,92 @@ describe LogStash::Filters::GeoIP do
       insist { subject["geoip"]["asn"].encoding } == Encoding::UTF_8
     end
   end
+
+  describe "defaults ipv6" do
+    v6db = ::Dir.glob(::File.expand_path("../../vendor/", ::File.dirname(__FILE__))+"/GeoLiteCityv6*.dat").first
+    config <<-CONFIG
+      filter {
+        geoip { 
+          source => "ip"
+          database => "#{v6db}"
+        }
+      }
+    CONFIG
+
+    sample("ip" => "2001:4860:4860::8888") do
+      insist { subject }.include?("geoip")
+      expected_fields = %w(ip country_code2 country_code3 country_name
+                           continent_code latitude longitude )
+      expected_fields.each do |f|
+        insist { subject["geoip"] }.include?(f)
+      end
+    end
+
+    sample("ip" => "fe80::1") do
+      # assume geoip fails on localhost lookups
+      reject { subject }.include?("geoip")
+    end
+  end
+
+  describe "Specify the target ipv6" do
+    v6db = ::Dir.glob(::File.expand_path("../../vendor/", ::File.dirname(__FILE__))+"/GeoLiteCityv6*.dat").first
+    config <<-CONFIG
+      filter {
+        geoip { 
+          source => "ip"
+          database => "#{v6db}"
+          target => src_ip
+        }
+      }
+    CONFIG
+
+    sample("ip" => "2001:4860:4860::8888") do
+      insist { subject }.include?("src_ip")
+
+      expected_fields = %w(ip country_code2 country_code3 country_name
+                           continent_code latitude longitude)
+      expected_fields.each do |f|
+        insist { subject["src_ip"] }.include?(f)
+      end
+    end
+
+    sample("ip" => "fe80::1") do
+      # assume geoip fails on localhost lookups
+      reject { subject }.include?("src_ip")
+    end
+  end
+
+  describe "correct encodings with ipv6 db" do
+    v6db = ::Dir.glob(::File.expand_path("../../vendor/", ::File.dirname(__FILE__))+"/GeoLiteCityv6*.dat").first
+    config <<-CONFIG
+      filter {
+        geoip {
+          source => "ip"
+          database => "#{v6db}"
+        }
+      }
+    CONFIG
+    expected_fields = %w(ip country_code2 country_code3 country_name
+                           continent_code)
+
+    sample("ip" => "2a03:2880:2110:df07:face:b00c:0:1") do
+      checked = 0
+      expected_fields.each do |f|
+        next unless subject["geoip"][f]
+        checked += 1
+        insist { subject["geoip"][f].encoding } == Encoding::UTF_8
+      end
+      insist { checked } > 0
+    end
+    sample("ip" => "2001:200:dff:fff1:216:3eff:feb1:44d7") do
+      checked = 0
+      expected_fields.each do |f|
+        next unless subject["geoip"][f]
+        checked += 1
+        insist { subject["geoip"][f].encoding } == Encoding::UTF_8
+      end
+      insist { checked } > 0
+    end
+
+  end
 end


### PR DESCRIPTION
Simple fix to support the IPv6 databases in the filter.

Fixes 
- https://logstash.jira.com/browse/LOGSTASH-1100

and partly
- https://logstash.jira.com/browse/LOGSTASH-1124
- https://logstash.jira.com/browse/LOGSTASH-2163

reworked from https://github.com/elasticsearch/logstash/pull/1350