### PR TITLE
Removed unnecessary escape characters

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -41,8 +41,8 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # are included in the event.
   #
   # For the built-in GeoLiteCity database, the following are available:
-  # `city\_name`, `continent\_code`, `country\_code2`, `country\_code3`, `country\_name`,
-  # `dma\_code`, `ip`, `latitude`, `longitude`, `postal\_code`, `region\_name` and `timezone`.
+  # `city_name`, `continent_code`, `country_code2`, `country_code3`, `country_name`,
+  # `dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_name` and `timezone`.
   config :fields, :validate => :array
 
   # Specify the field into which Logstash should store the geoip data.


### PR DESCRIPTION
There are some backslashes in there that are rendered to the html as well. Adding the backslash to the filter config will cause the field to not be created.

I haven't tested the resulting Ruby code but I can see that in other files the underscores are not escaped.