### PR TITLE
Include `location` field even if longitude and latitude are excluded

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -119,6 +119,10 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     geo_data_hash = geo_data.to_hash
     geo_data_hash.delete(:request)
     event[@target] = {} if event[@target].nil?
+    if geo_data_hash.key?(:latitude) && geo_data_hash.key?(:longitude)
+      # If we have latitude and longitude values, add the location field as GeoJSON array
+      geo_data_hash[:location] = [ geo_data_hash[:longitude].to_f, geo_data_hash[:latitude].to_f ]
+    end
     geo_data_hash.each do |key, value|
       next if value.nil? || (value.is_a?(String) && value.empty?)
       if @fields.nil? || @fields.empty? || @fields.include?(key.to_s)
@@ -136,10 +140,6 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
         event[@target][key.to_s] = value
       end
     end # geo_data_hash.each
-    if event[@target].key?('latitude') && event[@target].key?('longitude')
-      # If we have latitude and longitude values, add the location field as GeoJSON array
-      event[@target]['location'] = [ event[@target]["longitude"].to_f, event[@target]["latitude"].to_f ]
-    end
     filter_matched(event)
   end # def filter
 end # class LogStash::Filters::GeoIP

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -118,4 +118,35 @@ describe LogStash::Filters::GeoIP do
       insist { subject["geoip"]["asn"].encoding } == Encoding::UTF_8
     end
   end
+
+  describe "location field" do
+    shared_examples_for "an event with a [geoip][location] field" do
+      subject(:event) { LogStash::Event.new("message" => "8.8.8.8") }
+      let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message", "fields" => ["country_name", "location", "longitude"]) }
+
+      before do
+        plugin.register
+        plugin.filter(event)
+      end
+
+      it "should have a location field" do
+        expect(event["[geoip][location]"]).not_to(be_nil)
+      end
+    end
+
+    context "when latitude field is excluded" do
+      let(:fields) { ["country_name", "location", "longitude"] }
+      it_behaves_like "an event with a [geoip][location] field"
+    end
+
+    context "when longitude field is excluded" do
+      let(:fields) { ["country_name", "location", "latitude"] }
+      it_behaves_like "an event with a [geoip][location] field"
+    end
+
+    context "when both latitude and longitude field are excluded" do
+      let(:fields) { ["country_name", "location"] }
+      it_behaves_like "an event with a [geoip][location] field"
+    end
+  end
 end


### PR DESCRIPTION
Reported in #19, if your `fields` setting excludes 'longitutde' and/or 'latitude', then a bug would cause the 'location' field to be absent as well.

Builds on #20 and adds test coverage.