### PR TITLE
Return StandardError where applicable

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -84,7 +84,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     when GeoIP::GEOIP_ISP_EDITION, GeoIP::GEOIP_ORG_EDITION
       :isp
     else
-      raise RuntimeException.new "This GeoIP database is not currently supported"
+      raise StandardError.new "This GeoIP database is not currently supported"
     end
 
     @threadkey = "geoip-#{self.object_id}"


### PR DESCRIPTION
```
sam@ubuntu logstash % bin/logstash agent -f ../elastic/config/haproxy.conf
The error reported is: 
  uninitialized constant LogStash::Filters::GeoIP::RuntimeException

After change

sam@ubuntu logstash % bin/logstash agent -f ../elastic/config/haproxy.conf
The error reported is: 
  This GeoIP database is not currently supported
sam@ubuntu logstash % 
```
