### PR TITLE
Inclusion in main branch: Geomapping for internal IPs

### DIFF
--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
+  s.add_runtime_dependency "logstash-core", "~> 1.5.0"
 
   s.add_runtime_dependency 'geoip', ['>= 1.3.2']
   s.add_runtime_dependency 'lru_redux', "~> 1.1.0"
-  s.add_runtime_dependency 'ipaddr'
+  s.add_runtime_dependency 'ipaddress'
   s.add_runtime_dependency 'json'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'geoip', ['>= 1.3.2']
   s.add_runtime_dependency 'lru_redux', "~> 1.1.0"
+  s.add_runtime_dependency 'ipaddr'
+  s.add_runtime_dependency 'json'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/sample/private-ips.json
+++ b/sample/private-ips.json
@@ -1,0 +1,17 @@
+{
+  "US-NYC": {
+    "geoip": {
+      "location": [
+        40.689563, -74.044533
+      ],
+      "country_name": "United States",
+      "continent_code": "NA",
+      "city_name": "New York",
+      "region_name": "NY",
+      "real_region_name": "NewYork"
+    },
+    "ip": [
+      "192.168.0.0-192.168.2.255"
+    ]
+  }
+}


### PR DESCRIPTION
This version has added support for an additional lookup table for IP addresses to geo information to enable geomapping for internal and edge gateway addresses that would otherwise be inaccurate or unavailable.

The approach is to use a JSON file with geoinformation and IP address range information that will be queried before the GeoIP DB and used in its place if there is a match.
