### PR TITLE
Logstash-core >= 2.0.0 < 3.0.0

### DIFF
--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
 
   s.add_runtime_dependency 'geoip', ['>= 1.3.2']
   s.add_runtime_dependency 'lru_redux', "~> 1.1.0"


### PR DESCRIPTION
This changes allow the plugins to work under theses versions:

- 2.0.0.snapshot*
- 2.X 
- 3.0.0.dev.

The plugins wont work under version:
- 3.0.0

Fixes https://github.com/elastic/logstash/pull/3986