### PR TITLE
Moved ensure_database inside the if block

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -175,10 +175,10 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end
 
   def get_geo_data_for_ip(ip)
-    ensure_database!
     if (cached = lookup_cache[ip])
       cached
     else
+      ensure_database!
       geo_data = Thread.current[threadkey].send(@geoip_type, ip)
       lookup_cache[ip] = geo_data
       geo_data


### PR DESCRIPTION
There is no real need to ensure the database when we are going to read from cache.
Saves a few cpu cycles and maybe some mutex wait time as well.
