### PR TITLE
Refactor: GeoIP Struct processing, convert to hash once and store in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.4
+ - Refactor GeoIP Struct to hash conversion to minimise repeated manipulation
+
 ## 2.0.3
  - Fix Issue 50, incorrect data returned when geo lookup fails
 

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '2.0.3'
+  s.version         = '2.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -264,17 +264,16 @@ describe LogStash::Filters::GeoIP do
 
   describe "returned object identities" do
     let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message") }
-    let(:geo_data) { plugin.get_geo_data_for_ip("8.8.8.8") }
+    let(:event) { LogStash::Event.new("message" => "8.8.8.8") }
+    let(:alt_event) { LogStash::Event.new("message" => "8.8.8.8") }
 
     before do
       plugin.register
     end
 
     it "should dup the objects" do
-      event = { "geoip" => {} }
-      alt_event = { "geoip" => {} }
-      plugin.apply_geodata(geo_data.to_hash, event)
-      plugin.apply_geodata(geo_data.to_hash, alt_event)
+      plugin.apply_geodata(plugin.get_geo_data(event), event)
+      plugin.apply_geodata(plugin.get_geo_data(alt_event), alt_event)
 
       event["geoip"].each do |k,v|
         alt_v = alt_event["geoip"][k]


### PR DESCRIPTION
NOTES TO REVIEWERS:
- Objective: to move the extensive and expensive hash manipulation (GeoIP Struct to hash) to the initial lookup and store the result in the cache.
