### PR TITLE
use fieldref to properly assign event field data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+ - Use proper field references
+
 ## 2.0.4
  - Refactor GeoIP Struct to hash conversion to minimise repeated manipulation
 

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -142,7 +142,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     geo_data_hash.each do |key, value|
       if @no_fields || @fields.include?(key)
         # can't dup numerics
-        event[@target][key] = value.is_a?(Numeric) ? value : value.dup
+        event["[#{@target}][#{key}]"] = value.is_a?(Numeric) ? value : value.dup
       end
     end # geo_data_hash.each
     true

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
this change is necessary to support the future Java Event. 

The previous construct 
```ruby
event[@target][key] = foo
```
is actually: 1- fetch field reference `@target` and return value, 2- create `key` in value and assign `foo`. 
this actually assumes the mutability of `event[@target]` by its reference, which work but is an actual implementation side-effect and not a contract. 

The correct way to assign Event field values is by using proper field references
```
event["[#{@target}][#{key}]"]
```

This relates to elastic/logstash#4264 and elastic/logstash#4191