### PR TITLE
Split ip field if it contains multiple ips, and lookup the first public ip.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.5
+  - Add support for asn database
+
 ## 4.0.4
   - Update of the GeoIP2 DB
   - Target should be merged and not completely overwritten (#98)

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -92,7 +92,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
 
   # list of ip patterns that private ips start with. TODO benchmark if regex would be faster here.
   config :private_ip_prefixes, :validate => :array, :required => false, :default => ["10.", "192.168." ,"172.16.", "172.17.", "172.18.", "172.19.",
-   "172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.", "172.26.", "172.27.", "172.28.", "172.29.", "172.30.", "172.31."]
+   "172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.", "172.26.", "172.27.", "172.28.", "172.29.", "172.30.", "172.31.", "127.0.0"]
 
   public
   def register
@@ -105,9 +105,6 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       end
     end
     @logger.info("Using geoip database", :path => @database)
-
-    @logger.debug("Private ip filter settings: filter_private_ips " + (filter_private_ips ? "true" : "false"))
-   
     # For the purpose of initializing this filter, geoip is initialized here but
     # not set as a global. The geoip module imposes a mutex, so the filter needs
     # to re-initialize this later in the filter() thread, and save that access
@@ -171,6 +168,8 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       else 
         ip = ip.first
       end
+    else
+      @logger.debug("Is string")# TODO remove
     end
     return ip
   end
@@ -184,6 +183,8 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
         return ip
       end
     end
+    @logger.debug("no public ip found in string " + ip_array.to_s+ ", returning nil") # TODO remove
+    return nil
   end
 
   def is_private(ip)

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -202,18 +202,14 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end
 
   def is_private(ip)
-    begin
-      ipo = IPAddr.new(ip)
-      @private_ips.each do | private_ip |
-        @logger.debug("Checking IP inclusion", :private_ip => private_ip, :network => ipo) # TODO remove
-        if private_ip.include?(ipo)
-          return true
-        end
+    ipo = IPAddr.new(ip)
+    @private_ips.each do | private_ip |
+      @logger.debug("Checking IP inclusion", :private_ip => private_ip, :network => ipo) # TODO remove
+      if private_ip.include?(ipo)
+        return true
       end
-      false
-    rescue => e
-      @logger.error("Couldnt check if ip is private.", :input_data => ip, :event => event)
     end
+    false
   end
 
   def get_geo_data(event)

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -202,14 +202,18 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end
 
   def is_private(ip)
-    ipo = IPAddr.new(ip)
-    @private_ips.each do | private_ip |
-      @logger.debug("Checking IP inclusion", :private_ip => private_ip, :network => ipo) # TODO remove
-      if private_ip.include?(ipo)
-        return true
+    begin
+      ipo = IPAddr.new(ip)
+      @private_ips.each do | private_ip |
+        @logger.debug("Checking IP inclusion", :private_ip => private_ip, :network => ipo) # TODO remove
+        if private_ip.include?(ipo)
+          return true
+        end
       end
+      false
+    rescue => e
+      @logger.error("Couldnt check if ip is private.", :input_data => ip, :event => event)
     end
-    false
   end
 
   def get_geo_data(event)

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -1,10 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
-require "json"
 require "logstash-filter-geoip_jars"
-require "ipaddr"
-
 
 java_import "java.net.InetAddress"
 java_import "com.maxmind.geoip2.DatabaseReader"

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -212,7 +212,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       end
       false
     rescue => e
-      @logger.error("Couldnt check if ip is private.", :input_data => ip, :event => event)
+      @logger.error("Couldnt check if ip is private.", :input_data => ip)
     end
   end
 

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -90,7 +90,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # String by which the ip field should be tokenized
   config :ip_split_symbol, :validate => :string, :required => false, :default => ","
 
-  # list of ip patterns that private ips start with. TODO benchmark if regex would be faster here.
+  # list of ip patterns that private ips start with. 
   config :private_ip_prefixes, :validate => :array, :required => false, :default => ["10.", "192.168." ,"172.16.", "172.17.", "172.18.", "172.19.",
    "172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.", "172.26.", "172.27.", "172.28.", "172.29.", "172.30.", "172.31.", "127.0.0"]
 
@@ -162,19 +162,16 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end
 
   def select_ip(ip)
-    @logger.debug("incoming: " + ip.to_s) # TODO remove
     if ip.nil?
       return nil
     end
     if ip.is_a? Array
-      @logger.debug("is array.") # TODO remove
       if @filter_private_ips 
         ip = get_public_ip(ip) 
       else 
         ip = ip.first
       end
     else
-      @logger.debug("Is string")# TODO remove
       if @filter_private_ips
         ip = get_public_ip(ip.split(@ip_split_symbol))
       # else: return original string
@@ -186,25 +183,19 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   def get_public_ip(ip_array)
     ip_array.each do | ip |
       ip = ip.strip
-      @logger.debug("testing ip " + ip.to_s) # TODO remove
       if !is_private(ip)
-        @logger.debug("returning ip " + ip.to_s) # TODO remove
         return ip
       end
     end
-    @logger.debug("no public ip found in string " + ip_array.to_s+ ", returning nil") # TODO remove
     return nil
   end
 
   def is_private(ip)
     @private_ip_prefixes.each do | prefix |
-       @logger.debug("testing private with prefix " + prefix + ": " + ip.to_s) # TODO remove
       if ip.start_with? prefix
-        @logger.debug("is private with prefix " + prefix + ": " + ip.to_s) # TODO remove
         return true
       end
     end
-    @logger.debug("is not private: " + ip.to_s) # TODO remove
     return false
   end
 

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -105,6 +105,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       end
     end
     @logger.info("Using geoip database", :path => @database)
+    if @filter_private_ips
+      @logger.info("Filtering private ips with delimiter " + @ip_split_symbol + " for prefixes " + @private_ip_prefixes.to_s)
+    end
     # For the purpose of initializing this filter, geoip is initialized here but
     # not set as a global. The geoip module imposes a mutex, so the filter needs
     # to re-initialize this later in the filter() thread, and save that access

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -163,9 +163,11 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
 
   def select_ip(ip)
     @logger.debug("incoming: " + ip.to_s) # TODO remove
-    ip = ip.split(@ip_split_symbol)
+    if ip.nil?
+      return nil
+    end
     if ip.is_a? Array
-      @logger.debug(" is array.") # TODO remove
+      @logger.debug("is array.") # TODO remove
       if @filter_private_ips 
         ip = get_public_ip(ip) 
       else 
@@ -173,6 +175,10 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       end
     else
       @logger.debug("Is string")# TODO remove
+      if @filter_private_ips
+        ip = get_public_ip(ip.split(@ip_split_symbol))
+      # else: return original string
+      end
     end
     return ip
   end

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -190,13 +190,13 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       ip = ip.first if ip.is_a? Array
       geo_data_hash = Hash.new
       ip_address = InetAddress.getByName(ip)
-      @logger.debug("Sending ip #{ip_address} to method #{@dbtype}")
+      #@logger.debug("Sending ip #{ip_address} to method #{@dbtype}")
       response = @parser.send(@dbtype,ip_address)
-      @logger.debug("Response: " + response.to_s)
+      #@logger.debug("Response: " + response.to_s)
       populate_geo_data(response, ip_address, geo_data_hash)
-      @logger.debug("Geodata: " + geo_data_hash.to_s)
+      #@logger.debug("Geodata: " + geo_data_hash.to_s)
     rescue com.maxmind.geoip2.exception.AddressNotFoundException => e
-      @logger.debug("IP not found!", :exception => e, :field => @source, :event => event)
+      #@logger.debug("IP not found!", :exception => e, :field => @source, :event => event)
     rescue java.net.UnknownHostException => e
       @logger.error("IP Field contained invalid IP address or hostname", :exception => e, :field => @source, :event => event)
     rescue Exception => e
@@ -206,7 +206,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     end
 
     if apply_geodata(geo_data_hash, event)
-      @logger.debug("geodata successfully applied.")
+      #@logger.debug("geodata successfully applied.")
       filter_matched(event)
     else
       tag_unsuccessful_lookup(event)
@@ -292,7 +292,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end # def populate_geo_data
 
   def tag_unsuccessful_lookup(event)
-    @logger.debug? && @logger.debug("IP #{event.get(@source)} was not found in the database", :event => event)
+    #@logger.debug? && #@logger.debug("IP #{event.get(@source)} was not found in the database", :event => event)
     @tag_on_failure.each{|tag| event.tag(tag)}
   end
 

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '4.0.4'
+  s.version         = '4.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -175,9 +175,7 @@ describe LogStash::Filters::GeoIP do
           filter {
             geoip {
               source => "ip"
-
               database => "#{CITYDB}"
-
             }
           }
         CONFIG
@@ -192,9 +190,7 @@ describe LogStash::Filters::GeoIP do
     end
 
     describe "filter method outcomes" do
-
       let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message", "add_tag" => "done", "database" => CITYDB) }
-
       let(:event) { LogStash::Event.new("message" => ipstring) }
 
       before do
@@ -218,7 +214,7 @@ describe LogStash::Filters::GeoIP do
       context "when the bad IP is two ip comma separated" do
         # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
         let(:ipstring) { "123.45.67.89,61.160.232.222" }
-        
+
         it "should set the target field to an empty hash" do
           expect(event.get("geoip")).to eq({})
         end
@@ -263,11 +259,6 @@ describe LogStash::Filters::GeoIP do
     end
 
   end
-
-  
-
-
-
 
   describe "an invalid database" do
     config <<-CONFIG

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -284,7 +284,7 @@ describe LogStash::Filters::GeoIP do
       plugin.register
     end
     
-    context "when ip is in a private network" do
+    context "when ip is in a private 10/8 network" do
 
       let(:event) { LogStash::Event.new("message" => "10.1.2.3" ) }
       before do
@@ -293,9 +293,22 @@ describe LogStash::Filters::GeoIP do
 
       it "should return nil" do
         expect(event["geoip"]).to be_nil
-        end
+        end # it
+      end # context
+
+     context "when ip is in a private 172.16/12 network" do
+
+      let(:event) { LogStash::Event.new("message" => "172.16.0.8" ) }
+      before do
+        plugin.filter(event)
       end
-    end
+
+      it "should return nil" do
+        expect(event["geoip"]).to be_nil
+        end # it
+      end # context
+       
+    end # describe
 
         
       

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -205,7 +205,7 @@ describe LogStash::Filters::GeoIP do
     end
 
     describe "filter method outcomes" do
-      let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message", "add_tag" => "done", "database" => ASNDB) }
+      let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message", "add_tag" => "done", "database" => ASNDB, "filter_private_ips" => false) }
       let(:event) { LogStash::Event.new("message" => ipstring) }
 
       before do

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -278,6 +278,52 @@ describe LogStash::Filters::GeoIP do
 
   end 
 
+  describe "private ips" do
+    let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message", "add_tag" => "done", "database" => ASNDB) }
+    before do
+      plugin.register
+    end
+    
+    context "when ip is in a private network" do
+
+      let(:event) { LogStash::Event.new("message" => "10.1.2.3" ) }
+      before do
+        plugin.filter(event)
+      end
+
+      it "should return nil" do
+        expect(event["geoip"]).to be_nil
+        end
+      end
+    end
+
+        
+      
+     
+=begin
+      let(:ipstring) { "172.16.0.8" }
+      it "should return nil" do
+        expect(event["geoip"]["number"]).to be_nil
+        expect(event["geoip"]["asn"]).to be_nil
+      end
+
+      let(:ipstring) { "192.168.8.15" }
+      it "should return nil" do
+        expect(event["geoip"]["number"]).to be_nil
+        expect(event["geoip"]["asn"]).to be_nil
+      end
+    end
+
+    context "when ip is not in a private network" do
+      let(:ipstring) { "172.15.0.8" }
+      it "should not return nil" do
+        expect(event["geoip"]["number"]).not_to be_nil
+        expect(event["geoip"]["asn"]).not_to be_nil
+      end
+=end
+
+
+
   describe "an invalid database" do
     config <<-CONFIG
           filter {

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -269,8 +269,9 @@ describe LogStash::Filters::GeoIP do
         # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
         let(:ipstring) { "123.45.67.89,61.160.232.222" }
 
-        it "should take the first public ip" do
-          expect(event["geoip"]).to eq("123.45.67.89")
+        it "should take the first public ip" do # {"number"=>"AS6619", "asn"=>"SamsungSDS Inc."}
+          expect(event["geoip"]["number"]).not_to be_nil
+          expect(event["geoip"]["asn"]).not_to be_nil
         end
       end
     end

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -307,33 +307,33 @@ describe LogStash::Filters::GeoIP do
         expect(event["geoip"]).to be_nil
         end # it
       end # context
-       
+
+     context "when ip is in a private 192.168/16 network" do
+
+      let(:event) { LogStash::Event.new("message" => "192.168.8.15" ) }
+      before do
+        plugin.filter(event)
+      end
+
+      it "should return nil" do
+        expect(event["geoip"]).to be_nil
+        end # it
+      end # context
+
+     context "when ip is not in a private network" do
+
+      let(:event) { LogStash::Event.new("message" => "172.15.0.8" ) }
+      before do
+        plugin.filter(event)
+      end
+
+      it "should not return nil" do
+        expect(event["geoip"]).not_to be_nil
+        end # it
+      end # context
+      
     end # describe
 
-        
-      
-     
-=begin
-      let(:ipstring) { "172.16.0.8" }
-      it "should return nil" do
-        expect(event["geoip"]["number"]).to be_nil
-        expect(event["geoip"]["asn"]).to be_nil
-      end
-
-      let(:ipstring) { "192.168.8.15" }
-      it "should return nil" do
-        expect(event["geoip"]["number"]).to be_nil
-        expect(event["geoip"]["asn"]).to be_nil
-      end
-    end
-
-    context "when ip is not in a private network" do
-      let(:ipstring) { "172.15.0.8" }
-      it "should not return nil" do
-        expect(event["geoip"]["number"]).not_to be_nil
-        expect(event["geoip"]["asn"]).not_to be_nil
-      end
-=end
 
 
 

--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,6 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "4f81a1ca5ac35f1e655f9686a6f3e9dc6550d668"
+        "sha1": "c08db055e11092c08f8a7ff1143ab9ca3ede2934"
     }
 ]


### PR DESCRIPTION
This adresses issue 58 https://github.com/logstash-plugins/logstash-filter-geoip/issues/58
When containing more than one ip, only the first non private (RFC1918) ip will be used for lookup. This is helpful if you want to remove proxy ips and use the actual client ip. 
If desired, this can be deactivated in the config to restore the previous behaviour.
