### PR TITLE
adding configuration to disable logging in case the given value

### DIFF
--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -45,6 +45,10 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # this field is an array, only the first value will be used.
   config :source, :validate => :string, :required => true
 
+  # Configuration to disable or enable the error logging, completely disables logging 
+  # useful in production environment
+  config :nologging, :validate => :boolean, :required => false, :default => false
+
   # An array of geoip fields to be included in the event.
   #
   # Possible fields depend on the database type. By default, all geoip fields
@@ -94,7 +98,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
         raise "You must specify 'database => ...' in your geoip filter (I looked for '#{@database}'"
       end
     end
-    @logger.info("Using geoip database", :path => @database)
+    if !nologging
+       @logger.info("Using geoip database", :path => @database)
+    end
     # For the purpose of initializing this filter, geoip is initialized here but
     # not set as a global. The geoip module imposes a mutex, so the filter needs
     # to re-initialize this later in the filter() thread, and save that access
@@ -157,9 +163,13 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     begin
       result = get_geo_data_for_ip(ip)
     rescue SocketError => e
-      @logger.error("IP Field contained invalid IP address or hostname", :field => @source, :event => event)
+      if !nologging
+          @logger.error("IP Field contained invalid IP address or hostname", :field => @source, :event => event)
+      end
     rescue StandardError => e
-      @logger.error("Unknown error while looking up GeoIP data", :exception => e, :field => @source, :event => event)
+      if !nologging
+          @logger.error("Unknown error while looking up GeoIP data", :exception => e, :field => @source, :event => event)
+      end
     end
     result
   end


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

is not a valid ip address.

In high eps rate if the incoming event is wrong values i.e. a string
inplace of an ip address, it would result in filling up of log files

use additional configuration nologging => true/false, the default
value is false