### PR TITLE
Use empty result when location is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.0-beta3
+ - Return empty result when IP lookup fails for location field (#70)
+
 # 3.0.0-beta2
  - Internal: Actually include the vendored jars
 

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -119,6 +119,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # to having multiple caches for different instances at different points in the pipeline, that would just increase the
   # number of cache misses and waste memory.
   config :lru_cache_size, :validate => :number, :default => 1000
+  
+  # Tags the event on failure to look up geo information. This can be used in later analysis.
+  config :tag_on_failure, :validate => :array, :default => ["_geoip_lookup_failure"]
 
   public
   def register
@@ -152,67 +155,98 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       ip = ip.first if ip.is_a? Array
       ip_address = InetAddress.getByName(ip)
       response = @parser.city(ip_address)
-      country = response.getCountry()
-      subdivision = response.getMostSpecificSubdivision()
-      city = response.getCity()
-      postal = response.getPostal()
-      location = response.getLocation()
-
-      geo_data_hash = Hash.new()
-
-      @fields.each do |field|
-        case field
-        when "city_name"
-          geo_data_hash["city_name"] = city.getName()
-        when "country_name"
-          geo_data_hash["country_name"] = country.getName()
-        when "continent_code"
-          geo_data_hash["continent_code"] = response.getContinent().getCode()
-        when "continent_name"
-          geo_data_hash["continent_name"] = response.getContinent().getName()
-        when "country_code2"
-          geo_data_hash["country_code2"] = country.getIsoCode()
-        when "country_code3"
-          geo_data_hash["country_code3"] = country.getIsoCode()
-        when "ip"
-          geo_data_hash["ip"] = ip_address.getHostAddress()
-        when "postal_code"
-          geo_data_hash["postal_code"] = postal.getCode()
-        when "dma_code"
-          geo_data_hash["dma_code"] = location.getMetroCode()
-        when "region_name"
-          geo_data_hash["region_name"] = subdivision.getName()
-        when "region_code"
-          geo_data_hash["region_code"] = subdivision.getIsoCode()
-        when "timezone"
-          geo_data_hash["timezone"] = location.getTimeZone()
-        when "location"
-          geo_data_hash["location"] = [ location.getLongitude(), location.getLatitude() ]
-        when "latitude"
-          geo_data_hash["latitude"] = location.getLatitude()
-        when "longitude"
-          geo_data_hash["longitude"] = location.getLongitude()
-        else
-          raise Exception.new("[#{field}] is not a supported field option.")
-        end
+      
+      if response.nil?
+        tag_unsuccesful_lookup(event)
+        set_data(event)
+        return
+      else  
+        geo_data_hash = populate_data(event, response, ip_address)
       end
-
+      
     rescue com.maxmind.geoip2.exception.AddressNotFoundException => e
       @logger.debug("IP not found!", :exception => e, :field => @source, :event => event)
-      event[@target] = {}
+      set_data(event)
       return
     rescue java.net.UnknownHostException => e
       @logger.error("IP Field contained invalid IP address or hostname", :exception => e, :field => @source, :event => event)
-      event[@target] = {}
+      set_data(event)
       return
     rescue Exception => e
       @logger.error("Unknown error while looking up GeoIP data", :exception => e, :field => @source, :event => event)
-      event[@target] = {}
-      return
+      # Dont' swallow this, bubble up for unknown issue
+      raise e
     end
-
+    
     event[@target] = geo_data_hash
 
     filter_matched(event)
   end # def filter
+  
+  def populate_data(event, response, ip_address)
+    country = response.getCountry()
+    subdivision = response.getMostSpecificSubdivision()
+    city = response.getCity()
+    postal = response.getPostal()
+    location = response.getLocation()
+
+    geo_data_hash = Hash.new()
+    
+    # if location is empty, there is no point populating geo data
+    # and most likely all other fields are empty as well
+    if location.getLatitude().nil? && location.getLongitude().nil?
+      tag_unsuccesful_lookup(event)
+      return geo_data_hash
+    end
+    
+    @fields.each do |field|
+      case field
+      when "city_name"
+        geo_data_hash["city_name"] = city.getName()
+      when "country_name"
+        geo_data_hash["country_name"] = country.getName()
+      when "continent_code"
+        geo_data_hash["continent_code"] = response.getContinent().getCode()
+      when "continent_name"
+        geo_data_hash["continent_name"] = response.getContinent().getName()
+      when "country_code2"
+        geo_data_hash["country_code2"] = country.getIsoCode()
+      when "country_code3"
+        geo_data_hash["country_code3"] = country.getIsoCode()
+      when "ip"
+        geo_data_hash["ip"] = ip_address.getHostAddress()
+      when "postal_code"
+        geo_data_hash["postal_code"] = postal.getCode()
+      when "dma_code"
+        geo_data_hash["dma_code"] = location.getMetroCode()
+      when "region_name"
+        geo_data_hash["region_name"] = subdivision.getName()
+      when "region_code"
+        geo_data_hash["region_code"] = subdivision.getIsoCode()
+      when "timezone"
+        geo_data_hash["timezone"] = location.getTimeZone()
+      when "location"
+        geo_data_hash["location"] = [ location.getLongitude(), location.getLatitude() ]
+      when "latitude"
+        geo_data_hash["latitude"] = location.getLatitude()
+      when "longitude"
+        geo_data_hash["longitude"] = location.getLongitude()
+      else
+        raise Exception.new("[#{field}] is not a supported field option.")
+      end
+    end
+    
+    return geo_data_hash
+    
+  end
+  
+  def tag_unsuccesful_lookup(event)
+    @logger.debug? && @logger.debug("IP #{event[@source]} was not found in the database", :event => event)
+    @tag_on_failure.each{|tag| event.tag(tag)}
+  end
+  
+  def set_data(event, geo_data = {}) 
+    event[@target] = geo_data
+  end
+    
 end # class LogStash::Filters::GeoIP

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -157,7 +157,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       response = @parser.city(ip_address)
       
       if response.nil?
-        tag_unsuccesful_lookup(event)
+        tag_unsuccessful_lookup(event)
         set_data(event)
         return
       else  
@@ -195,7 +195,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     # if location is empty, there is no point populating geo data
     # and most likely all other fields are empty as well
     if location.getLatitude().nil? && location.getLongitude().nil?
-      tag_unsuccesful_lookup(event)
+      tag_unsuccessful_lookup(event)
       return geo_data_hash
     end
     
@@ -240,7 +240,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     
   end
   
-  def tag_unsuccesful_lookup(event)
+  def tag_unsuccessful_lookup(event)
     @logger.debug? && @logger.debug("IP #{event[@source]} was not found in the database", :event => event)
     @tag_on_failure.each{|tag| event.tag(tag)}
   end

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -163,7 +163,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       else  
         geo_data_hash = populate_data(event, response, ip_address)
       end
-      
+
     rescue com.maxmind.geoip2.exception.AddressNotFoundException => e
       @logger.debug("IP not found!", :exception => e, :field => @source, :event => event)
       set_data(event)
@@ -177,7 +177,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
       # Dont' swallow this, bubble up for unknown issue
       raise e
     end
-    
+
     event[@target] = geo_data_hash
 
     filter_matched(event)
@@ -237,16 +237,15 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
     end
     
     return geo_data_hash
-    
   end
-  
+
   def tag_unsuccessful_lookup(event)
     @logger.debug? && @logger.debug("IP #{event[@source]} was not found in the database", :event => event)
     @tag_on_failure.each{|tag| event.tag(tag)}
   end
-  
+
   def set_data(event, geo_data = {}) 
     event[@target] = geo_data
   end
-    
+
 end # class LogStash::Filters::GeoIP

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '3.0.0.beta2'
+  s.version         = '3.0.0.beta3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -186,6 +186,36 @@ describe LogStash::Filters::GeoIP do
           expect(event["geoip"]).to eq({})
         end
       end
+      
+      context "when a IP is not found in the DB" do
+        # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
+        let(:ipstring) { "113.208.89.21" }
+
+        it "should set the target field to an empty hash" do
+          expect(event["geoip"]).to eq({})
+          expect(event["tags"]).to include("_geoip_lookup_failure")
+        end
+      end
+      
+      context "when IP is IPv6 format for localhost" do
+        # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
+        let(:ipstring) { "::1" }
+
+        it "should set the target field to an empty hash" do
+          expect(event["geoip"]).to eq({})
+        end
+      end
+      
+      context "when IP is IPv6 format" do
+        # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
+        let(:ipstring) { "2607:f0d0:1002:51::4" }
+
+        it "should set the target field to an empty hash" do
+          expect(event["geoip"]).not_to be_empty
+          expect(event["geoip"]["city_name"]).not_to be_nil
+        end
+      end
+      
     end
 
     context "should return the correct source field in the logging message" do
@@ -214,5 +244,5 @@ describe LogStash::Filters::GeoIP do
       end
     end
   end
-
+  
 end

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -173,7 +173,7 @@ describe LogStash::Filters::GeoIP do
           expect(event["geoip"]).to eq({})
         end
 
-        it "should not have added any tags" do
+        it "should add failure tags" do
           expect(event["tags"]).to include("_geoip_lookup_failure")
         end
       end

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -174,7 +174,7 @@ describe LogStash::Filters::GeoIP do
         end
 
         it "should not have added any tags" do
-          expect(event["tags"]).to be_nil
+          expect(event["tags"]).to include("_geoip_lookup_failure")
         end
       end
 

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -188,7 +188,6 @@ describe LogStash::Filters::GeoIP do
       end
       
       context "when a IP is not found in the DB" do
-        # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
         let(:ipstring) { "113.208.89.21" }
 
         it "should set the target field to an empty hash" do
@@ -198,7 +197,6 @@ describe LogStash::Filters::GeoIP do
       end
       
       context "when IP is IPv6 format for localhost" do
-        # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
         let(:ipstring) { "::1" }
 
         it "should set the target field to an empty hash" do
@@ -207,7 +205,6 @@ describe LogStash::Filters::GeoIP do
       end
       
       context "when IP is IPv6 format" do
-        # regression test for issue https://github.com/logstash-plugins/logstash-filter-geoip/issues/51
         let(:ipstring) { "2607:f0d0:1002:51::4" }
 
         it "should set the target field to an empty hash" do
@@ -244,5 +241,5 @@ describe LogStash::Filters::GeoIP do
       end
     end
   end
-  
+
 end


### PR DESCRIPTION
For some IPs location and most fields are nil. Its better to return empty geoip than Elasticsearch barfing with mapping errors.

Also added tests for IPv6 now that GeoIP2 supports it
Fixes #70