### PR TITLE
Alias the install_jars method to vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ rvm:
 before_install: []
 script:
 - bundle exec rake vendor
-- bundle exec rake install_jars
 - bundle exec rspec spec
 jdk: oraclejdk8

--- a/Rakefile
+++ b/Rakefile
@@ -7,11 +7,12 @@ task :default do
   system("rake -T")
 end
 
+require "logstash/devutils/rake"
 require 'jars/installer'
 task :install_jars do
   ENV['JARS_HOME'] = Dir.pwd + "/vendor/jar-dependencies/runtime-jars"
   ENV['JARS_VENDOR'] = "false"
   Jars::Installer.new.vendor_jars!(false)
 end
+task :vendor => :install_jars
 
-require "logstash/devutils/rake"


### PR DESCRIPTION
Our build bot and our mass publish process require a unified way of
making the gem and will execute the following tasks:

```
bundle install
bundle exec rake vendor
bundle exec rspec
```
This PR alias the `install_jars` to vendor to make it uniform with our
other tools.