### PR TITLE
Allow include/exclude fields in the geoip filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,22 @@
+## 5.0.0
+  - [#6] [Breaking change] Allow the inclusion/exclusion of the "extra", location  is the default one, but all others could be added through the fields parameter. See https://github.com/logstash-plugins/logstash-filter-geoip/issues/6 for details.
+
 ## 4.0.0
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
   - GA release for GeoIP2 database, compatible with LS 5.x
 
-# 3.0.0-beta3
+## 3.0.0-beta3
  - Return empty result when IP lookup fails for location field (#70)
 
-# 3.0.0-beta2
+## 3.0.0-beta2
  - Internal: Actually include the vendored jars
 
-# 3.0.0-beta1 
+## 3.0.0-beta1 
  - Changed plugin to use GeoIP2 database. See http://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/
 
-# 2.0.7
+## 2.0.7
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.6
+## 2.0.6
   - New dependency requirements for logstash-core for the 5.0 release
 ## 2.0.5
  - Use proper field references

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -69,11 +69,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   # For the built-in GeoLiteCity database, the following are available:
   # `city_name`, `continent_code`, `country_code2`, `country_code3`, `country_name`,
   # `dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_name` and `timezone`.
-  config :fields, :validate => :array, :default => ['city_name', 'continent_code',
-                                                    'country_code2', 'country_code3', 'country_name',
-                                                    'dma_code', 'ip', 'latitude',
-                                                    'longitude', 'postal_code', 'region_name',
-                                                    'region_code', 'timezone', 'location']
+  config :fields, :validate => :array, :default => ['location']
 
   # Specify the field into which Logstash should store the geoip data.
   # This can be useful, for example, if you have `src\_ip` and `dst\_ip` fields and

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '4.0.0'
+  s.version         = '5.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -3,11 +3,6 @@ require "logstash/filters/geoip"
 
 CITYDB = ::Dir.glob(::File.expand_path("../../vendor/", ::File.dirname(__FILE__))+"/GeoLite2-City.mmdb").first
 
-# %w(ip country_code2 country_code3 country_name
-#                             continent_code region_name city_name postal_code
-#                             latitude longitude dma_code timezone
-#                             location )
-
 describe LogStash::Filters::GeoIP do
 
   describe "defaults" do

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -3,6 +3,11 @@ require "logstash/filters/geoip"
 
 CITYDB = ::Dir.glob(::File.expand_path("../../vendor/", ::File.dirname(__FILE__))+"/GeoLite2-City.mmdb").first
 
+# %w(ip country_code2 country_code3 country_name
+#                             continent_code region_name city_name postal_code
+#                             latitude longitude dma_code timezone
+#                             location )
+
 describe LogStash::Filters::GeoIP do
 
   describe "defaults" do
@@ -10,21 +15,13 @@ describe LogStash::Filters::GeoIP do
       filter {
         geoip {
           source => "ip"
-          #database => "#{CITYDB}"
         }
       }
     CONFIG
 
     sample("ip" => "8.8.8.8") do
       insist { subject }.include?("geoip")
-
-      expected_fields = %w(ip country_code2 country_code3 country_name
-                           continent_code region_name city_name postal_code
-                           latitude longitude dma_code timezone
-                           location )
-      expected_fields.each do |f|
-        insist { subject.get("geoip") }.include?(f)
-      end
+      insist { subject.get("geoip") }.include?("location")
     end
 
     sample("ip" => "127.0.0.1") do
@@ -38,7 +35,7 @@ describe LogStash::Filters::GeoIP do
       filter {
         geoip {
           source => "ip"
-          #database => "#{CITYDB}"
+          fields => [ 'ip', 'location' ]
           target => src_ip
           add_tag => "done"
         }
@@ -49,19 +46,20 @@ describe LogStash::Filters::GeoIP do
 
       sample("ip" => "8.8.8.8") do
         expect(subject).to include("src_ip")
-
-        expected_fields = %w(ip country_code2 country_code3 country_name
-                             continent_code region_name city_name postal_code
-                             latitude longitude dma_code timezone
-                             location )
-        expected_fields.each do |f|
-          expect(subject.get("src_ip")).to include(f)
-        end
+        expect(subject.get("src_ip")).to include("location")
       end
 
       sample("ip" => "127.0.0.1") do
         # assume geoip fails on localhost lookups
         expect(subject.get("src_ip")).to eq({})
+      end
+    end
+
+
+    context "when specifying extra new fields" do
+      sample("ip" => "8.8.8.8") do
+        expect(subject).to include("src_ip")
+        expect(subject.get("src_ip")).to include("ip")
       end
     end
 
@@ -77,12 +75,11 @@ describe LogStash::Filters::GeoIP do
       filter {
         geoip {
           source => "ip"
+          fields => [ 'ip', 'country_code2', 'country_code3', 'country_name', 'continent_code', 'region_name', 'city_name', 'postal_code', 'dma_code',  'timezone', 'location' ]
         }
       }
     CONFIG
-    expected_fields = %w(ip country_code2 country_code3 country_name
-                           continent_code region_name city_name postal_code
-                           dma_code timezone)
+    expected_fields = %w(ip country_code2 country_code3 country_name continent_code region_name city_name postal_code dma_code timezone)
 
     sample("ip" => "1.1.1.1") do
       checked = 0
@@ -157,7 +154,12 @@ describe LogStash::Filters::GeoIP do
     end
 
     describe "filter method outcomes" do
-      let(:plugin) { LogStash::Filters::GeoIP.new("source" => "message", "add_tag" => "done", "database" => CITYDB) }
+      let(:config) do
+        {
+          "source" => "message", "add_tag" => "done", "database" => CITYDB, "fields" => ["location", "city_name"]
+        }
+      end
+      let(:plugin) { LogStash::Filters::GeoIP.new(config) }
       let(:event) { LogStash::Event.new("message" => ipstring) }
 
       before do


### PR DESCRIPTION

* make location the default field, others could be added through the fields config option
* updated spec with detailed test, plus version bump an changelog update

Fixes #6 