### PR TITLE
set spec encoding to utf-8

### DIFF
--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/geoip"
 


### PR DESCRIPTION
Test fails because encoding is ASCII

Fixes https://github.com/elastic/logstash/issues/5347