### PR TITLE
update sha1 for vendored database

### DIFF
--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,6 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "ba960d536948d9d296b334ac99b7e6a4a6b6e431"
+        "sha1": "f114479cce49091b32ca17974accb63c93d5b46d"
     }
 ]


### PR DESCRIPTION
```
% wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz &&  shasum GeoLite2-City.mmdb.gz
--2016-07-14 16:08:43--  http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
Resolving geolite.maxmind.com... 104.16.37.47, 104.16.38.47, 2400:cb00:2048:1::6810:262f, ...
Connecting to geolite.maxmind.com|104.16.37.47|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 30727809 (29M) [application/octet-stream]
Saving to: 'GeoLite2-City.mmdb.gz'

GeoLite2-City.mmdb.gz           100%[======================================================>]  29.30M  3.81MB/s    in 9.1s    

2016-07-14 16:08:52 (3.23 MB/s) - 'GeoLite2-City.mmdb.gz' saved [30727809/30727809]

f114479cce49091b32ca17974accb63c93d5b46d  GeoLite2-City.mmdb.gz
```

fixes https://travis-ci.org/logstash-plugins/logstash-filter-geoip/builds/144738435