### PR TITLE
fix "ip not found" spec using 0.0.0.0 instead of random ip

### DIFF
--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -188,7 +188,7 @@ describe LogStash::Filters::GeoIP do
       end
       
       context "when a IP is not found in the DB" do
-        let(:ipstring) { "113.208.89.21" }
+        let(:ipstring) { "0.0.0.0" }
 
         it "should set the target field to an empty hash" do
           expect(event.get("geoip")).to eq({})


### PR DESCRIPTION
the "ip not found" spec was using a specific ip that now shows up in the latest version of the geo ip database.
this pr changes the test to use 0.0.0.0, which we know won't show up.