### PR TITLE
add encoding header to spec file

### DIFF
--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/geoip"
 


### PR DESCRIPTION
avoid:

```
Failures:

  1) LogStash::Filters::GeoIP an invalid IP filter method outcomes when IP is IPv6 format should set the target field to an empty hash
     Failure/Error: before do
     RuntimeError:
       expected UTF-8 encoding for value=done, encoding=#<Encoding:US-ASCII>
     # ./logstash-core-event/lib/logstash/event.rb:226:in `validate_value'
     # ./logstash-core-event/lib/logstash/event.rb:230:in `validate_value'
     # ./logstash-core-event/lib/logstash/event.rb:230:in `validate_value'
     # ./vendor/bundle/jruby/1.9/gems/logstash-devutils-0.0.22-java/lib/logstash/devutils/rspec/spec_helper.rb:43:in `[]='
     # ./logstash-core/lib/logstash/util/decorators.rb:46:in `add_tags'
     # ./logstash-core/lib/logstash/util/decorators.rb:38:in `add_tags'
     # ./logstash-core/lib/logstash/filters/base.rb:180:in `filter_matched'
     # ./vendor/bundle/jruby/1.9/gems/logstash-filter-geoip-4.0.2-java/lib/logstash/filters/geoip.rb:179:in `filter'
     # ./vendor/bundle/jruby/1.9/gems/logstash-filter-geoip-4.0.2-java/spec/filters/geoip_spec.rb:165:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `(root)'
     # ./rakelib/test.rake:72:in `(root)'
```
