### PR TITLE
Small improvements for the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.3
+  - Update of the GeoIP2 DB
 ## 4.0.2
   - Recreate gem since 4.0.1 lacked jars
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,5 @@ task :install_jars do
 end
 
 require "logstash/devutils/rake"
+
+task :vendor => :install_jars

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,6 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "f114479cce49091b32ca17974accb63c93d5b46d"
+        "sha1": "19190da72e067b158079ca03964f05781ce475b7"
     }
 ]


### PR DESCRIPTION
This PR contains the following changes:

- Update sha1 for the new GeoIP DB.
- `rake vendor` will now invoke `rake install_jars` to make it work with Jarvis/doc tool.
