### PR TITLE
Update SHA-1 of the GeoLite2-City database file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 vendor
 .idea
 lib/com
+Jars.lock

--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,6 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "26a8c17e03bfc540d3cf109d0ecd3d1f44ab7eff"
+        "sha1": "b8a0a7ea6e1a9e871c09f3583ad992453e4eb0e3"
     }
 ]


### PR DESCRIPTION
The previous hash is no longer valid. The new one is for the
GeoLite2-City database from MaxMind which is timestamped March 7th,
2017.

Also add Jars.lock to .gitignore.