### PR TITLE
Look up continent/country/region/city GeoName IDs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 Gemfile.lock
+Jars.lock
 .bundle
 vendor
 .idea

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -63,7 +63,8 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   #
   # For the built-in GeoLite2 City database, the following are available:
   # `city_name`, `continent_code`, `country_code2`, `country_code3`, `country_name`,
-  # `dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_name` and `timezone`.
+  # `dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_name`, `timezone`,
+  # `continent_geoname_id`, `country_geoname_id`, `region_geoname_id`, and `city_geoname_id`.
   config :fields, :validate => :array, :default => ['city_name', 'continent_code',
                                                     'country_code2', 'country_code3', 'country_name',
                                                     'dma_code', 'ip', 'latitude',
@@ -214,6 +215,14 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
         geo_data_hash["latitude"] = location.getLatitude()
       when "longitude"
         geo_data_hash["longitude"] = location.getLongitude()
+      when "city_geoname_id"
+        geo_data_hash["city_geoname_id"] = city.getGeoNameId()
+      when "region_geoname_id"
+        geo_data_hash["region_geoname_id"] = subdivision.getGeoNameId()
+      when "country_geoname_id"
+        geo_data_hash["country_geoname_id"] = country.getGeoNameId()
+      when "continent_geoname_id"
+        geo_data_hash["continent_geoname_id"] = response.getContinent().getGeoNameId()
       else
         raise Exception.new("[#{field}] is not a supported field option.")
       end

--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,6 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "26a8c17e03bfc540d3cf109d0ecd3d1f44ab7eff"
+        "sha1": "09e9d5e1be282444f2a43ce4733eb8b1142cc63e"
     }
 ]


### PR DESCRIPTION
For backwards-compatibility, GeoName IDs are only included if explicitly
added to the `fields` option.

Also, update the database SHA-1 and fix an unrelated test warning due to
over-broad exception handling.