### PR TITLE
Update GeoIP2 City database

### DIFF
--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -20,9 +20,7 @@ describe LogStash::Filters::GeoIP do
       insist { subject }.include?("geoip")
 
       expected_fields = %w(ip country_code2 country_code3 country_name
-                           continent_code region_name city_name postal_code
-                           latitude longitude dma_code timezone
-                           location )
+                           continent_code latitude longitude location)
       expected_fields.each do |f|
         insist { subject.get("geoip") }.include?(f)
       end
@@ -52,9 +50,7 @@ describe LogStash::Filters::GeoIP do
         expect(subject).to include("src_ip")
 
         expected_fields = %w(ip country_code2 country_code3 country_name
-                             continent_code region_name city_name postal_code
-                             latitude longitude dma_code timezone
-                             location )
+                             continent_code latitude longitude location)
         expected_fields.each do |f|
           expect(subject.get("src_ip")).to include(f)
         end

--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,6 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "69d209236a96f2a3f27de30c6cf954b56edb916e"
+        "sha1": "dc594fb45880bb33767f3280f2f108389f24db22"
     }
 ]


### PR DESCRIPTION
The tests had to be modified because the latest DB does not populate these fields for
test IP 8.8.8.8
