### PR TITLE
Bundle ASN database in vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+  - Bundle the GeoLite2-ASN database by default
+  - Add default_database_type configuration option to allow selection between the GeoLite2-City and GeoLote2-ASN databases.
+
 ## 4.2.0
   - Add support for GeoLite2-ASN database from Maxmind for ASN data.
   - Update Java dependencies to 2.9.0 to support the new ASN database.

--- a/build.gradle
+++ b/build.gradle
@@ -67,10 +67,6 @@ dependencies {
   compileOnly fileTree(dir: logstashCoreEventGemPath, include: '**/*.jar')
 }
 
-test {
-  dependsOn 'downloadASNDatabaseForTest'
-}
-
 task rubyBootstrap << {
   description "Try bundler"
   def jruby = new org.jruby.embed.ScriptingContainer()
@@ -124,21 +120,6 @@ task vendor << {
   File projectJarFile = file("${vendorPathPrefix}/${projectGroupPath}/${project.name}/${project.version}/${project.name}-${project.version}.jar")
   projectJarFile.mkdirs()
   Files.copy(file("$buildDir/libs/${project.name}-${project.version}.jar").toPath(), projectJarFile.toPath(), REPLACE_EXISTING)
-}
-
-String databaseRootResource = 'http://geolite.maxmind.com/download/geoip/database/'
-
-task downloadASNDatabaseForTest(type: Download, overwrite: false) {
-  src([
-    databaseRootResource + 'GeoLite2-ASN.tar.gz'
-  ])
-  dest file("build")
-  doLast {
-    copy {
-      from tarTree('build/GeoLite2-ASN.tar.gz')
-      into file("build")
-    }
-  }
 }
 
 vendor.dependsOn(jar, generateGemJarRequiresFile)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,14 +25,14 @@ based on data from the Maxmind GeoLite2 databases.
 
 ==== Supported Databases
 
-This plugin is bundled with https://dev.maxmind.com/geoip/geoip2/geolite2[GeoLite2] City database out of the box. From Maxmind's description -- 
-"GeoLite2 databases are free IP geolocation databases comparable to, but less accurate than, MaxMind’s 
+This plugin is bundled with https://dev.maxmind.com/geoip/geoip2/geolite2[GeoLite2] City database out of the box. From Maxmind's description --
+"GeoLite2 databases are free IP geolocation databases comparable to, but less accurate than, MaxMind’s
 GeoIP2 databases". Please see GeoIP Lite2 license for more details.
 
 https://www.maxmind.com/en/geoip2-databases[Commercial databases] from Maxmind are also supported in this plugin.
 
-If you need to use databases other than the bundled GeoLite2 City, you can download them directly 
-from Maxmind's website and use the `database` option to specify their location. The GeoLite2 databases 
+If you need to use databases other than the bundled GeoLite2 City, you can download them directly
+from Maxmind's website and use the `database` option to specify their location. The GeoLite2 databases
 can be downloaded from https://dev.maxmind.com/geoip/geoip2/geolite2[here].
 
 If you would like to get Autonomous System Number(ASN) information, you can use the GeoLite2-ASN database.
@@ -72,6 +72,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-cache_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-database>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-default_database_type>> |`City` or `ASN`|No
 | <<plugins-{type}s-{plugin}-fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<array,array>>|No
@@ -84,7 +85,7 @@ filter plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-cache_size"]
-===== `cache_size` 
+===== `cache_size`
 
   * Value type is <<number,number>>
   * Default value is `1000`
@@ -105,7 +106,7 @@ to having multiple caches for different instances at different points in the pip
 number of cache misses and waste memory.
 
 [id="plugins-{type}s-{plugin}-database"]
-===== `database` 
+===== `database`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -117,8 +118,17 @@ GeoIP2-City, GeoIP2-ISP, GeoIP2-Country are the commercial databases from Maxmin
 If not specified, this will default to the GeoLite2 City database that ships
 with Logstash.
 
+[id="plugins-{type}s-{plugin}-default_database_type"]
+===== `default_database_type`
+
+This plugin now includes both the GeoLite2-City and GeoLite2-ASN databases.  If `database` and `default_database_type` are unset, the GeoLite2-City database will be selected.  To use the included GeoLite2-ASN database, set `default_database_type` to `ASN`.
+
+  * Value type is <<string,string>>
+  * The default value is `City`
+  * The only acceptable values are `City` and `ASN`
+
 [id="plugins-{type}s-{plugin}-fields"]
-===== `fields` 
+===== `fields`
 
   * Value type is <<array,array>>
   * There is no default value for this setting.
@@ -155,7 +165,7 @@ to having multiple caches for different instances at different points in the pip
 number of cache misses and waste memory.
 
 [id="plugins-{type}s-{plugin}-source"]
-===== `source` 
+===== `source`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -165,7 +175,7 @@ The field containing the IP address or hostname to map via geoip. If
 this field is an array, only the first value will be used.
 
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
-===== `tag_on_failure` 
+===== `tag_on_failure`
 
   * Value type is <<array,array>>
   * Default value is `["_geoip_lookup_failure"]`
@@ -173,7 +183,7 @@ this field is an array, only the first value will be used.
 Tags the event on failure to look up geo information. This can be used in later analysis.
 
 [id="plugins-{type}s-{plugin}-target"]
-===== `target` 
+===== `target`
 
   * Value type is <<string,string>>
   * Default value is `"geoip"`

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -33,11 +33,14 @@ require "logstash-filter-geoip_jars"
 class LogStash::Filters::GeoIP < LogStash::Filters::Base
   config_name "geoip"
 
-  # The path to the GeoLite2 database file which Logstash should use. Only City database is supported by now.
+  # The path to the GeoLite2 database file which Logstash should use. City and ASN databases are supported.
   #
   # If not specified, this will default to the GeoLite2 City database that ships
   # with Logstash.
   config :database, :validate => :path
+
+  # If using the default database, which type should Logstash use.  Valid values are "City" and "ASN", and case matters.
+  config :default_database_type, :validate => ["City","ASN"], :default => "City"
 
   # The field containing the IP address or hostname to map via geoip. If
   # this field is an array, only the first value will be used.
@@ -104,7 +107,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   public
   def register
     if @database.nil?
-      @database = ::Dir.glob(::File.join(::File.expand_path("../../../vendor/", ::File.dirname(__FILE__)),"GeoLite2-City.mmdb")).first
+      @database = ::Dir.glob(::File.join(::File.expand_path("../../../vendor/", ::File.dirname(__FILE__)),"GeoLite2-#{@default_database_type}.mmdb")).first
 
       if @database.nil? || !File.exists?(@database)
         raise "You must specify 'database => ...' in your geoip filter (I looked for '#{@database}')"

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '4.2.1'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -3,8 +3,6 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/geoip"
 
 CITYDB = ::Dir.glob(::File.expand_path("../../vendor/", ::File.dirname(__FILE__))+"/GeoLite2-City.mmdb").first
-# this is downloaded in build dir so we don't accidentally package this database when creating a gem
-ASNDB = ::Dir.glob(::File.expand_path("../../build/GeoLite2-ASN_*", ::File.dirname(__FILE__))+"/GeoLite2-ASN.mmdb").first
 
 describe LogStash::Filters::GeoIP do
 
@@ -39,7 +37,7 @@ describe LogStash::Filters::GeoIP do
       filter {
         geoip {
           source => "ip"
-          #database => "#{CITYDB}"
+          # database => "#{CITYDB}"
           target => src_ip
           add_tag => "done"
         }
@@ -273,7 +271,8 @@ describe LogStash::Filters::GeoIP do
       filter {
         geoip {
           source => "ip"
-          database => "#{ASNDB}"
+          # database => "" # use the bundled ASN
+          default_database_type => "ASN"
         }
       }
     CONFIG

--- a/vendor.json
+++ b/vendor.json
@@ -1,6 +1,14 @@
 [
     {
         "url": "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz",
-        "sha1": "dc594fb45880bb33767f3280f2f108389f24db22"
+        "sha1": "5f1d57e747b06e4c40a34db8dbb5b04651434ffd"
+    },
+    {
+        "url": "https://s3.amazonaws.com/download.elasticsearch.org/logstash/maxmind/GeoLite2-ASN.mmdb",
+        "sha1": "d968898454106a56a9b5a5d0e7f7465fc93c6800"
+    },
+    {
+        "url": "https://s3.amazonaws.com/download.elasticsearch.org/logstash/maxmind/LICENSE.txt",
+        "sha1": "9f7561e561089d23f49aa3ce9ff055c4ad6b2920"
     }
 ]


### PR DESCRIPTION
Changes:

* Add new `default_database_type` option to allow selection between `City` and `ASN` type.
* Add ASN db download and license download to vendor.json
* Updated SHA1 hash for newer version of GeoLite2-City mmdb
* Updated rspec tests to test both `default_database_type` and new ASN db file in vendor path
* Updated documentation to reflect new configuration and ASN availability.
* Bump plugin version to 4.3.0
* Remove now-unneeded ASN db downloading task in build.gradle

fixes #126 