### PR TITLE
Fields is missing region_code

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -140,7 +140,8 @@ are included in the event.
 
 For the built-in GeoLite2 City database, the following are available:
 `city_name`, `continent_code`, `country_code2`, `country_code3`, `country_name`,
-`dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_name` and `timezone`.
+`dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_code`,
+`region_name` and `timezone`.
 
 [id="plugins-{type}s-{plugin}-source"]
 ===== `source`


### PR DESCRIPTION
`region_code` is still a valid field to extract, but was not in the docs.

On a separate note, I believe that `country_code3` is no longer 3 characters, but 2 (extracted from the same field as `country_code2`), and perhaps should continue to exist, since users may expect it.

