### PR TITLE
Fields is missing region_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.3
+  - Fixed docs for missing region_code [#158](https://github.com/logstash-plugins/logstash-filter-geoip/pull/158)
+
 ## 6.0.2
   - Update of GeoLite2 DB [#157](https://github.com/logstash-plugins/logstash-filter-geoip/pull/157)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -140,7 +140,8 @@ are included in the event.
 
 For the built-in GeoLite2 City database, the following are available:
 `city_name`, `continent_code`, `country_code2`, `country_code3`, `country_name`,
-`dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_name` and `timezone`.
+`dma_code`, `ip`, `latitude`, `longitude`, `postal_code`, `region_code`,
+`region_name` and `timezone`.
 
 [id="plugins-{type}s-{plugin}-source"]
 ===== `source`

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '6.0.2'
+  s.version         = '6.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Adds geographical information about an IP address"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Reboot of #156 

`region_code` is still a valid field to extract, but was not in the docs.
