### PR TITLE
Enable the use of MaxMind GeoIP2-Domain databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.4
+  - Enable the use of MaxMind GeoIP2-Domain databases [#162](https://github.com/logstash-plugins/logstash-filter-geoip/pull/162)
+
 ## 6.0.3
   - Fixed docs for missing region_code [#158](https://github.com/logstash-plugins/logstash-filter-geoip/pull/158)
 

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '6.0.3'
+  s.version         = '6.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Adds geographical information about an IP address"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/src/main/java/org/logstash/filters/Fields.java
+++ b/src/main/java/org/logstash/filters/Fields.java
@@ -32,6 +32,7 @@ enum Fields {
   CONTINENT_NAME("continent_name"),
   COUNTRY_CODE2("country_code2"),
   COUNTRY_CODE3("country_code3"),
+  DOMAIN("domain"),
   IP("ip"),
   ISP("isp"),
   POSTAL_CODE("postal_code"),
@@ -69,6 +70,8 @@ enum Fields {
 
   static final EnumSet<Fields> DEFAULT_ASN_LITE_FIELDS = EnumSet.of(Fields.IP, Fields.AUTONOMOUS_SYSTEM_NUMBER,
       Fields.AUTONOMOUS_SYSTEM_ORGANIZATION);
+
+  static final EnumSet<Fields> DEFAULT_DOMAIN_FIELDS = EnumSet.of(Fields.DOMAIN);
 
   public static Fields parseField(String value) {
     try {

--- a/src/main/java/org/logstash/filters/GeoIPFilter.java
+++ b/src/main/java/org/logstash/filters/GeoIPFilter.java
@@ -25,6 +25,7 @@ import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.AsnResponse;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
+import com.maxmind.geoip2.model.DomainResponse;
 import com.maxmind.geoip2.model.IspResponse;
 import com.maxmind.geoip2.record.*;
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +57,7 @@ public class GeoIPFilter {
   private static final String CITY_SOUTH_AMERICA_DB_TYPE = "GeoIP2-City-South-America";
   private static final String COUNTRY_DB_TYPE = "GeoIP2-Country";
   private static final String ISP_DB_TYPE = "GeoIP2-ISP";
+  private static final String DOMAIN_DB_TYPE = "GeoIP2-Domain";
 
   private final String sourceField;
   private final String targetField;
@@ -99,6 +101,8 @@ public class GeoIPFilter {
         case ASN_LITE_DB_TYPE:
           desiredFields = Fields.DEFAULT_ASN_LITE_FIELDS;
           break;
+        case DOMAIN_DB_TYPE:
+          desiredFields = Fields.DEFAULT_DOMAIN_FIELDS;
       }
     } else {
       for (String fieldName : fields) {
@@ -152,6 +156,9 @@ public class GeoIPFilter {
           break;
         case ISP_DB_TYPE:
           geoData = retrieveIspGeoData(ipAddress);
+          break;
+        case DOMAIN_DB_TYPE:
+          geoData = retrieveDomainGeoData(ipAddress);
           break;
         default:
           throw new IllegalStateException("Unsupported database type " + databaseReader.getMetadata().getDatabaseType() + "");
@@ -395,6 +402,21 @@ public class GeoIPFilter {
           if (aso != null) {
             geoData.put(Fields.AUTONOMOUS_SYSTEM_ORGANIZATION.fieldName(), aso);
           }
+          break;
+      }
+    }
+
+    return geoData;
+  }
+
+  private Map<String, Object> retrieveDomainGeoData(InetAddress ipAddress) throws GeoIp2Exception, IOException {
+    DomainResponse response = databaseReader.domain(ipAddress);
+    Map<String, Object> geoData = new HashMap<>();
+    for (Fields desiredField : this.desiredFields) {
+      switch (desiredField) {
+        case DOMAIN:
+          String domain = response.getDomain();
+          geoData.put(Fields.DOMAIN.fieldName(), domain);
           break;
       }
     }


### PR DESCRIPTION
In addition to the location databases, MaxMind provides a database of domain data as well. This change enables the use of the GeoIP2-Domain database by whitelisting the appropriate field.