### PR TITLE
Change database expire action to fail the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.1.1
-  - Changed the behaviour of database expiry. Instead of failing the ingestion pipeline, it adds a tag [#182](https://github.com/logstash-plugins/logstash-filter-geoip/pull/182)
+  - Changed the behaviour of database expiry. Instead of stopping the pipeline, it adds a tag `_geoip_expired_database` [#182](https://github.com/logstash-plugins/logstash-filter-geoip/pull/182)
 
 ## 7.1.0
   - Add ECS compatibility [#179](https://github.com/logstash-plugins/logstash-filter-geoip/pull/179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.1
+  - Changed the behaviour of database expiry. Instead of failing the ingestion pipeline, it adds a tag [#182](https://github.com/logstash-plugins/logstash-filter-geoip/pull/182)
+
 ## 7.1.0
   - Add ECS compatibility [#179](https://github.com/logstash-plugins/logstash-filter-geoip/pull/179)
 

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -158,7 +158,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end
 
   def fail_filter
-    @logger.info("geoip plugin stop filtering")
+    @logger.warn("geoip plugin will stop filtering and will tag all events with the '_geoip_expired_database' tag.")
     @healthy_database = false
   end
 

--- a/lib/logstash/filters/geoip.rb
+++ b/lib/logstash/filters/geoip.rb
@@ -148,7 +148,7 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   def setup_filter(database_path)
     @healthy_database = true
     @database = database_path
-    @logger.info("Using geoip database", :path => @database)
+    @logger.info("Using geoip database", :path => @database, :healthy_database => @healthy_database)
     @geoipfilter = org.logstash.filters.geoip.GeoIPFilter.new(@source, @target, @fields, @database, @cache_size, ecs_compatibility.to_s)
   end
 
@@ -158,8 +158,9 @@ class LogStash::Filters::GeoIP < LogStash::Filters::Base
   end
 
   def fail_filter
-    @logger.warn("geoip plugin will stop filtering and will tag all events with the '_geoip_expired_database' tag.")
     @healthy_database = false
+    @logger.warn("geoip plugin will stop filtering and will tag all events with the '_geoip_expired_database' tag.",
+                 :healthy_database => @healthy_database)
   end
 
   def terminate_filter

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '7.1.0'
+  s.version         = '7.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Adds geographical information about an IP address"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/test_helper.rb
+++ b/spec/filters/test_helper.rb
@@ -1,12 +1,16 @@
 require "logstash-core/logstash-core"
 require "digest"
 
-def get_vendor_path
-  ::File.expand_path("../../vendor/", ::File.dirname(__FILE__))
+def get_vendor_path(filename)
+  ::File.join(::File.expand_path("../../vendor/", ::File.dirname(__FILE__)), filename)
+end
+
+def get_data_dir
+  ::File.join(LogStash::SETTINGS.get_value("path.data"), "plugins", "filters", "geoip")
 end
 
 def get_file_path(filename)
-  ::File.join(get_vendor_path, filename)
+  ::File.join(get_data_dir, filename)
 end
 
 def get_metadata_database_name
@@ -14,8 +18,8 @@ def get_metadata_database_name
 end
 
 METADATA_PATH = get_file_path("metadata.csv")
-DEFAULT_CITY_DB_PATH = get_file_path("GeoLite2-City.mmdb")
-DEFAULT_ASN_DB_PATH = get_file_path("GeoLite2-ASN.mmdb")
+DEFAULT_CITY_DB_PATH = get_vendor_path("GeoLite2-City.mmdb")
+DEFAULT_ASN_DB_PATH = get_vendor_path("GeoLite2-ASN.mmdb")
 
 major, minor = LOGSTASH_VERSION.split(".")
 MAJOR = major.to_i


### PR DESCRIPTION
This PR goes together with https://github.com/elastic/logstash/pull/12884
The PR changes the behaviour of database expiry. Instead of stopping the pipeline, it fails the pipeline by adding a tag `_geoip_expired_database` to the event.


Fixed: https://github.com/elastic/logstash/issues/12860
