### PR TITLE
Fixed resolving wrong `fields` name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.1.3
-  - Fixed resolving wrong `fields` name `AUTONOMOUS_SYSTEM_NUMBER` and `AUTONOMOUS_SYSTEM_ORGANIZATION`
+  - Fixed resolving wrong `fields` name `AUTONOMOUS_SYSTEM_NUMBER` and `AUTONOMOUS_SYSTEM_ORGANIZATION` [#185](https://github.com/logstash-plugins/logstash-filter-geoip/pull/185)
 
 ## 7.1.2
   - Remove EULA doc as MaxMind auto-update has been retargeted to a later release [#183](https://github.com/logstash-plugins/logstash-filter-geoip/pull/183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.3
+  - Fixed resolving wrong `fields` name `AUTONOMOUS_SYSTEM_NUMBER` and `AUTONOMOUS_SYSTEM_ORGANIZATION`
+
 ## 7.1.2
   - Remove EULA doc as MaxMind auto-update has been retargeted to a later release [#183](https://github.com/logstash-plugins/logstash-filter-geoip/pull/183)
 

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '7.1.2'
+  s.version         = '7.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Adds geographical information about an IP address"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/geoip_offline_spec.rb
+++ b/spec/filters/geoip_offline_spec.rb
@@ -294,4 +294,22 @@ describe LogStash::Filters::GeoIP do
     end
   end
 
+  describe "GeoIP2-ASN database with fields" do
+    config <<-CONFIG
+      filter {
+        geoip {
+          source => "ip"
+          database => "#{ASNDB}"
+          default_database_type => "ASN"
+          fields => [ "AUTONOMOUS_SYSTEM_NUMBER" ]
+        }
+      }
+    CONFIG
+
+    sample("ip" => "8.8.8.8") do
+      expect(subject.get("geoip")).not_to be_empty
+      expect(subject.get("geoip")["asn"]).to eq(15169)
+    end
+  end
+
 end

--- a/src/main/java/org/logstash/filters/geoip/Fields.java
+++ b/src/main/java/org/logstash/filters/geoip/Fields.java
@@ -84,7 +84,7 @@ enum Fields {
     static {
       final Map<String,Fields> mapping = new HashMap<>();
       for (Fields value : values()) {
-        mapping.put(value.fieldName().toUpperCase(Locale.ROOT), value);
+        mapping.put(value.name().toUpperCase(Locale.ROOT), value);
     }
     MAPPING = Collections.unmodifiableMap(mapping);
   }


### PR DESCRIPTION
`AUTONOMOUS_SYSTEM_NUMBER` and `AUTONOMOUS_SYSTEM_ORGANIZATION` failed to be resolved in config
``` 
	geoip {
		default_database_type => "ASN"
		fields => [ "AUTONOMOUS_SYSTEM_NUMBER", "AUTONOMOUS_SYSTEM_ORGANIZATION" ]
	}
```
which cause error log
``[2021-06-10T12:32:45,387][ERROR][logstash.javapipeline    ][main] Pipeline error {:pipeline_id=>"main", :exception=>java.lang.IllegalArgumentException: illegal field value AUTONOMOUS_SYSTEM_NUMBER. valid values are [AUTONOMOUS_SYSTEM_NUMBER, AUTONOMOUS_SYSTEM_ORGANIZATION, CITY_NAME, COUNTRY_NAME, CONTINENT_CODE, CONTINENT_NAME, COUNTRY_CODE2, COUNTRY_CODE3, DOMAIN, IP, ISP, POSTAL_CODE, DMA_CODE, REGION_NAME, REGION_CODE, TIMEZONE, LOCATION, LATITUDE, LONGITUDE, ORGANIZATION]``

These are the only two fields having a different name in output
the rest of them are the same
`IP` ->`ip`
`CITY_NAME` -> `city_name` 
`AUTONOMOUS_SYSTEM_NUMBER` -> `asn`
