### PR TITLE
[Doc] bootstrap air-gapped environment for auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.2.3
+  - [DOC] Add documentation for bootstrapping air-gapped environment for database auto-update [#189](https://github.com/logstash-plugins/logstash-filter-geoip/pull/189)
+
 ## 7.2.2
   - [DOC] Add documentation for database auto-update behavior and database metrics [#187](https://github.com/logstash-plugins/logstash-filter-geoip/pull/187)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -92,7 +92,7 @@ http://dev.maxmind.com/geoip/geoip2/geolite2[MaxMind site].
 
 . Copy your database files to a single directory.
 
-. Download {es} from https://www.elastic.co/downloads/elasticsearch[Elastic]
+. https://www.elastic.co/downloads/elasticsearch[Download {es}].
 
 . From your {es} directory, run:
 +

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -73,6 +73,14 @@ TIP: When possible, allow Logstash to access the internet to download databases 
 [id="plugins-{type}s-{plugin}-manage_update"]
 ==== Manage your own database updates
 
+**Use a proxy endpoint**
+
+If you can't connect directly to the Elastic GeoIP endpoint, consider setting up
+a secure proxy. You can then specify the proxy endpoint URL in the
+`xpack.geoip.download.endpoint` setting in `logstash.yml` file.
+
+**Use a custom endpoint**
+
 If you work in air-gapped environment and can't update your databases from the Elastic endpoint,
 you can bootstrap the environment as follows.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,6 +70,41 @@ Events will be tagged with `_geoip_expired_database` tag to facilitate the handl
 
 TIP: When possible, allow Logstash to access the internet to download databases so that they are always up-to-date.
 
+[id="plugins-{type}s-{plugin}-manage_update"]
+==== Manage your own database updates
+
+If you work in air-gapped environment and can't update your databases from the Elastic endpoint,
+you can bootstrap the environment as follows.
+
+You can create a service that mimics the Elastic GeoIP endpoint. You can then
+get automatic updates from this service.
+
+. Download your `.mmdb` database files from the
+http://dev.maxmind.com/geoip/geoip2/geolite2[MaxMind site].
+
+. Copy your database files to a single directory.
+
+. Download {es} from https://www.elastic.co/downloads/elasticsearch[Elastic]
+
+. From your {es} directory, run:
++
+[source,sh]
+----
+./bin/elasticsearch-geoip -s my/database/dir
+----
+
+. Serve the static database files from your directory. For example, you can use
+Docker to serve the files from nginx server:
++
+[source,sh]
+----
+docker run -p 8080:80 -v my/database/dir:/usr/share/nginx/html:ro nginx
+----
+
+. Specify the service's endpoint URL
+`xpack.geoip.download.endpoint=http://localhost:8080/overview.json` in `logstash.yml`.
+
+
 [id="plugins-{type}s-{plugin}-metrics"]
 ==== Database Metrics
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -109,8 +109,8 @@ Docker to serve the files from nginx server:
 docker run -p 8080:80 -v my/database/dir:/usr/share/nginx/html:ro nginx
 ----
 
-. Specify the service's endpoint URL
-`xpack.geoip.download.endpoint=http://localhost:8080/overview.json` in `logstash.yml`.
+. Specify the service's endpoint URL using the
+`xpack.geoip.download.endpoint=http://localhost:8080/overview.json` setting in `logstash.yml`.
 
 
 [id="plugins-{type}s-{plugin}-metrics"]

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '7.2.2'
+  s.version         = '7.2.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Adds geographical information about an IP address"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is the document update for https://github.com/elastic/logstash/pull/13104 to teach users how to bootstrap a server in air-gapped environment. The content is taken from [elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html#ingest-geoip-downloader-endpoint) and modified to fit logstash usage

CI red is fixed in logstash-core. Once core is merged, CI should be green