### PR TITLE
[Doc] air-gapped environment requires ASN and City databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.2.10
+  - [DOC] air-gapped environment requires both ASN and City databases [#204](https://github.com/logstash-plugins/logstash-filter-geoip/pull/204)
+
 ## 7.2.9
   - Fix: red CI in Logstash 8.0 [#201](https://github.com/logstash-plugins/logstash-filter-geoip/pull/201)
   - Update Log4j dependency to 2.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.2.10
-  - [DOC] air-gapped environment requires both ASN and City databases [#204](https://github.com/logstash-plugins/logstash-filter-geoip/pull/204)
+  - [DOC] Air-gapped environment requires both ASN and City databases [#204](https://github.com/logstash-plugins/logstash-filter-geoip/pull/204)
 
 ## 7.2.9
   - Fix: red CI in Logstash 8.0 [#201](https://github.com/logstash-plugins/logstash-filter-geoip/pull/201)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -89,7 +89,7 @@ You can then download databases from MaxMind and bootstrap the service.
 . Download both `GeoLite2-ASN.mmdb` and `GeoLite2-City.mmdb` database files from the
 http://dev.maxmind.com/geoip/geoip2/geolite2[MaxMind site].
 
-. Copy your database files to a single directory.
+. Copy both database files to a single directory.
 
 . https://www.elastic.co/downloads/elasticsearch[Download {es}].
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -86,7 +86,7 @@ a secure proxy. You can then specify the proxy endpoint URL in the
 If you work in air-gapped environment and can't update your databases from the Elastic endpoint,
 You can then download databases from MaxMind and bootstrap the service.
 
-. Download your `.mmdb` database files from the
+. Download both `GeoLite2-ASN.mmdb` and `GeoLite2-City.mmdb` database files from the
 http://dev.maxmind.com/geoip/geoip2/geolite2[MaxMind site].
 
 . Copy your database files to a single directory.

--- a/logstash-filter-geoip.gemspec
+++ b/logstash-filter-geoip.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-geoip'
-  s.version         = '7.2.9'
+  s.version         = '7.2.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Adds geographical information about an IP address"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Related issue: [#13577](https://github.com/elastic/logstash/issues/13577)

Users report an issue of the script in air-gapped environment when they interest to a single type of database.
However, the current endpoint expects both types of database.
