### PR TITLE
Fix ECS field region_iso_code

### DIFF
--- a/src/main/java/org/logstash/filters/geoip/Fields.java
+++ b/src/main/java/org/logstash/filters/geoip/Fields.java
@@ -38,7 +38,7 @@ enum Fields {
   POSTAL_CODE("geo.postal_code", "postal_code"),
   DMA_CODE("mmdb.dma_code", "dma_code"),
   REGION_NAME("geo.region_name", "region_name"),
-  REGION_CODE("geo.region_code", "region_code"),
+  REGION_CODE("geo.region_iso_code", "region_code"),
   TIMEZONE("geo.timezone", "timezone"),
   LOCATION("geo.location", "location"),
   LATITUDE("geo.location.lat", "latitude"),


### PR DESCRIPTION
This commit changes the ECS field from `geo.region_code` to `geo.region_iso_code`

Before this change, `52.168.174.229` gives `region_code`: `VA`

The source of `region_code` is Maxmind `iso_code`. `region_code` is not a ECS field but `region_iso_code` is.
In ECS example the value of`region_iso_code` is `CA-QC`, which seems to be a combination of country iso code and region iso code. So, the current `region_code` is not the same as ECS schema `region_iso_code`.

Questions: 
1. Can we change `geo.region_code` to `geo.region_iso_code` or keep it as is?
2. Should we use country iso code and region iso code to build ECS `regsion_iso_code`?

Fixed: #195 