### PR TITLE
Changed geoip online spec to mock additional x-pack settings

### DIFF
--- a/spec/filters/geoip_online_spec.rb
+++ b/spec/filters/geoip_online_spec.rb
@@ -15,6 +15,8 @@ describe LogStash::Filters::GeoIP do
       dir_path = Stud::Temporary.directory
       File.open(dir_path + '/uuid', 'w') { |f| f.write(SecureRandom.uuid) }
       allow(LogStash::SETTINGS).to receive(:get).and_call_original
+      allow(LogStash::SETTINGS).to receive(:get).with("xpack.geoip.downloader.enabled").and_return(true)
+      allow(LogStash::SETTINGS).to receive(:get).with("xpack.geoip.download.endpoint").and_return(nil)
       allow(LogStash::SETTINGS).to receive(:get).with("path.data").and_return(dir_path)
     end
 


### PR DESCRIPTION
This PR mocks the additional x-pack settings to avoid missing configuration errors like `Setting "xpack.geoip.downloader.enabled" doesn't exist. Please check if you haven't made a typo`.

Additional x-pack settings are registered when the plugin extension is loaded, which never happens on unit tests.
