### PR TITLE
Updated spec syntax to work on JRuby 9.4

### DIFF
--- a/spec/filters/geoip_offline_spec.rb
+++ b/spec/filters/geoip_offline_spec.rb
@@ -112,7 +112,7 @@ describe LogStash::Filters::GeoIP do
         CONFIG
 
     context "should return the correct sourcefield in the logging message" do
-      sample("ip" => "8.8.8.8") do
+      sample({"ip" => "8.8.8.8"}) do
         expect { subject }.to raise_error(java.lang.IllegalArgumentException, "The database provided is invalid or corrupted.")
       end
     end


### PR DESCRIPTION
Fix dictionary definition passed into the spec methods, to be compliant with JRuby 9.4

## How to test
same steps as https://github.com/logstash-plugins/logstash-filter-cidr/pull/26