### PR TITLE
[DOCS] Fix typo in YAML example

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -120,7 +120,7 @@ docker run -p 8080:80 -v my/database/dir:/usr/share/nginx/html:ro nginx
 ----
 
 . Specify the service's endpoint URL using the
-`xpack.geoip.download.endpoint=http://localhost:8080/overview.json` setting in `logstash.yml`.
+`xpack.geoip.download.endpoint: http://localhost:8080/overview.json` setting in `logstash.yml`.
 
 Logstash gets automatic updates from this service.
 


### PR DESCRIPTION
The logstash.yml is YAML and therefore requires to use `:` instead of `=`